### PR TITLE
Added set_waveform command + bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,13 +120,22 @@ The Light API provides everything in the Device API, as well as:
 # color is a HSBK list of values: [hue (0-65535), saturation (0-65535), brightness (0-65535), Kelvin (2500-9000)]
 # duration is the transition time in milliseconds
 # rapid is True/False. If True, don't wait for successful confirmation, just send multiple packets and move on
-# NOTE: rapid is meant for super-fast light shows with lots of changes. You should't need it for normal use. 
+# NOTE: rapid is meant for super-fast light shows with lots of changes. You should't need it for normal use.
+# transient is 1 to return to the original color of the light after the specified number of cycles.
+# transient is 0 the light is left set to _color_ after the specified number of cycles.
+# period is the length of one cycle in milliseconds.
+# cycles is the number of times to repeat the waveform
+# duty-cycle is 0 for an equal amount of time to be spent on the original color and the new color
+# duty_cycle is positive for more time to be spent on the original color
+# duty_cycle is negative for more time to be spent on the new color.
+# waveform 0 = Saw, 1 = Sine, 2 = HalfSine, 3 = Triangle, 4 = Pulse
 # arguments in [square brackets] are optional
 
 set_power(power, [duration], [rapid])   
 set_color(color, [duration], [rapid])                                   
 get_power()                             # returns 0 or 65535
-get_color()                             # returns color (HSBK list
+get_color()                             # returns color (HSBK list)
+set_waveform(transient, color, period, cycles, duty-cycle, waveform)
 ```
 
 The Light API also provides macros for basic colors, like RED, BLUE, GREEN, etc. Setting colors is as easy as `mybulb.set_color(BLUE)`. See light.py for complete list of color macros.

--- a/lifxlan/device.py
+++ b/lifxlan/device.py
@@ -206,11 +206,11 @@ class Device(object):
         return build, version
 
     def get_wifi_firmware_build_timestamp(self):
-        self.wifi_firmware_build_timestamp, self.wifi_firmware_version = self._get_wifi_firmware_tuple()
+        self.wifi_firmware_build_timestamp, self.wifi_firmware_version = self.get_wifi_firmware_tuple()
         return self.wifi_firmware_build_timestamp
 
     def get_wifi_firmware_version(self):
-        self.wifi_firmware_build_timestamp, self.wifi_firmware_version = self._get_wifi_firmware_tuple()
+        self.wifi_firmware_build_timestamp, self.wifi_firmware_version = self.get_wifi_firmware_tuple()
         return self.wifi_firmware_version
 
     def get_version_tuple(self):
@@ -424,8 +424,10 @@ class Device(object):
                 timedout = True if elapsed_time > timeout_secs else False
             attempts += 1
         if not success:
+            self.close_socket()
             raise IOError("WorkflowException: Did not receive {} in response to {}".format(str(response_type), str(msg_type)))
-        self.close_socket()
+        else:
+            self.close_socket()
         return device_response
 
     # Not currently implemented, although the LIFX LAN protocol supports this kind of workflow natively

--- a/lifxlan/lifxlan.py
+++ b/lifxlan/lifxlan.py
@@ -200,8 +200,10 @@ class LifxLAN:
                 timedout = True if elapsed_time > timeout_secs else False
             attempts += 1
         if success == False:
+            self.close_socket()
             raise WorkflowException("Did not receive {} in response to {}".format(str(response_type), str(msg_type)))
-        self.close_socket()
+        else:
+            self.close_socket()
         return responses
 
     def broadcast_with_ack(self, msg_type, payload={}, timeout_secs=DEFAULT_TIMEOUT+0.5, max_attempts=DEFAULT_ATTEMPTS):

--- a/lifxlan/light.py
+++ b/lifxlan/light.py
@@ -55,6 +55,17 @@ class Light(Device):
         except WorkflowException as e:
             print(e)
 
+    # color is [Hue, Saturation, Brightness, Kelvin]
+    def set_waveform(self, transient, color, period, cycles, duty_cycle, waveform, rapid=False):
+        if len(color) == 4:
+            try:
+                if rapid:
+                    self.fire_and_forget(LightSetWaveform, {"transient": transient, "color": color, "period": period, "cycles": cycles, "duty_cycle": duty_cycle, "waveform": waveform}, num_repeats=5)
+                else:
+                    self.req_with_ack(LightSetWaveform, {"transient": transient, "color": color, "period": period, "cycles": cycles, "duty_cycle": duty_cycle, "waveform": waveform})
+            except WorkflowException as e:
+                print(e)
+
     # color is [Hue, Saturation, Brightness, Kelvin], duration in ms
     def set_color(self, color, duration=0, rapid=False):
         if len(color) == 4:

--- a/lifxlan/msgtypes.py
+++ b/lifxlan/msgtypes.py
@@ -340,6 +340,31 @@ class LightSetColor(Message):
         color = "".join(little_endian(bitstring.pack("16", field)) for field in self.color)
         duration = little_endian(bitstring.pack("32", self.duration))
         payload = reserved_8 + color + duration
+        payloadUi = " ".join("{:02x}".format(ord(c)) for c in payload)
+        return payload
+
+
+class LightSetWaveform(Message):
+    def __init__(self, target_addr, source_id, seq_num, payload, ack_requested=False, response_requested=False):
+        self.transient = payload["transient"]
+        self.color = payload["color"]
+        self.period = payload["period"]
+        self.cycles = payload["cycles"]
+        self.duty_cycle = payload["duty_cycle"]
+        self.waveform = payload["waveform"]
+        super(LightSetWaveform, self).__init__(MSG_IDS[LightSetWaveform], target_addr, source_id, seq_num, ack_requested, response_requested)
+
+    def get_payload(self):
+        reserved_8 = little_endian(bitstring.pack("8", self.reserved))
+        transient = little_endian(bitstring.pack("uint:8", self.transient))
+        color = "".join(little_endian(bitstring.pack("16", field)) for field in self.color)
+        period = little_endian(bitstring.pack("uint:32", self.period))
+        cycles = little_endian(bitstring.pack("float:32", self.cycles))
+        duty_cycle = little_endian(bitstring.pack("int:16", self.duty_cycle))
+        waveform = little_endian(bitstring.pack("uint:8", self.waveform))
+        payload = reserved_8 + transient + color + period + cycles + duty_cycle + waveform
+
+        payloadUi = " ".join("{:02x}".format(ord(c)) for c in payload)
         return payload
 
 
@@ -428,6 +453,7 @@ MSG_IDS = {     GetService: 2,
                 EchoResponse: 59,
                 LightGet: 101,
                 LightSetColor: 102,
+                LightSetWaveform: 103,
                 LightState: 107,
                 LightGetPower: 116,
                 LightSetPower: 117,


### PR DESCRIPTION
Corrected device.py and lifxlan.py closing socket when io error
detected e.g LIFX lamp being physically switched off and the back on
again a while later.

Added in ‘set_waveform’ processing - as advocated here by Patrick
Pelletier - https://github.com/LIFX/lifx-protocol-docs/pull/12/files